### PR TITLE
Tratamento do Response na geração de boleto

### DIFF
--- a/src/Getnet/API/BaseResponse.php
+++ b/src/Getnet/API/BaseResponse.php
@@ -249,7 +249,7 @@ class BaseResponse implements \JsonSerializable
             $this->status = "ERROR";
         } elseif ($this->status_code == 500) {
             $this->status = "ERROR";
-        } elseif ($this->status_code == 1) {
+        } elseif ($this->status_code == 1 || isset($this->redirect_url)) {
             $this->status = "PENDING";
         } elseif (isset($this->status_label)) {
             $this->status = $this->status_label;

--- a/src/Getnet/API/BaseResponse.php
+++ b/src/Getnet/API/BaseResponse.php
@@ -249,7 +249,7 @@ class BaseResponse implements \JsonSerializable
             $this->status = "ERROR";
         } elseif ($this->status_code == 500) {
             $this->status = "ERROR";
-        } elseif (isset($this->redirect_url)) {
+        } elseif ($this->status_code == 1) {
             $this->status = "PENDING";
         } elseif (isset($this->status_label)) {
             $this->status = $this->status_label;


### PR DESCRIPTION
Ao gerar boleto o `getStatus() `estava retornando `EM ABERTO`, porém o correto deveria ser `PENDING`.
Isso ocorre pois o `status_code` que a GetNet retorna é 1, e este `status_code` não está mapeado no getStatus().