### PR TITLE
Melhoria BaseResponse para análise de erros

### DIFF
--- a/src/Getnet/API/BaseResponse.php
+++ b/src/Getnet/API/BaseResponse.php
@@ -46,6 +46,10 @@ class BaseResponse implements \JsonSerializable
     /**
      * @var
      */
+    public $message;
+    /**
+     * @var
+     */
     public $error_message;
     /**
      * @var
@@ -59,6 +63,10 @@ class BaseResponse implements \JsonSerializable
      * @var
      */
     public $status_code;
+    /**
+     * @var
+     */
+    public $error_code;
     /**
      * @var
      */
@@ -314,5 +322,33 @@ class BaseResponse implements \JsonSerializable
     public function setResponseJSON($array)
     {
         $this->responseJSON = json_encode($array, JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getErrorCode() {
+        return $this->error_code;
+    }
+
+    /**
+     * @param mixed $error_code
+     */
+    public function setErrorCode($error_code): void {
+        $this->error_code = $error_code;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMessage() {
+        return $this->message;
+    }
+
+    /**
+     * @param mixed $message
+     */
+    public function setMessage($message): void {
+        $this->message = $message;
     }
 }


### PR DESCRIPTION
Incluídos duas novas propriedades no BaseResponse que estavam vindo no JSON da GetNet e não estavam sendo tratadas.
Essas propriedades facilitam principalmente a interpretação do erro de retorno.

![image](https://user-images.githubusercontent.com/9328453/82454116-c5eb0e00-9a87-11ea-957d-52c1d9896fc3.png)
